### PR TITLE
Update marzban-setup.sh

### DIFF
--- a/marzban/marzban-setup.sh
+++ b/marzban/marzban-setup.sh
@@ -110,14 +110,20 @@ mkdir -p $DIR
 if [[ ! -f "$DIR/fullchain.pem" ]]; then
     curl -s https://get.acme.sh | sh -s email=$EMAIL_FOR_CERTIFICATE_ISSUE
 
+    #Сертификат будет обновляться каждые 60 дней по умолчанию. После обновления сертификата marzban будет автоматически перезагружен. 
     ~/.acme.sh/acme.sh \
         --set-default-ca \
-        --server letsencrypt  \
+        --server letsencrypt \
         --issue \
         --standalone \
+        -d $SUBSCRIPTION_DOMAIN
+
+   ~/.acme.sh/acme.sh \
+        -d $SUBSCRIPTION_DOMAIN \
+        --installcert \
         --key-file $DIR/key.pem \
         --fullchain-file $DIR/fullchain.pem \
-        -d $SUBSCRIPTION_DOMAIN
+        --reloadcmd "marzban restart -n"
 
     echo 'UVICORN_SSL_CERTFILE = "/var/lib/marzban/certs/fullchain.pem"' >> /opt/marzban/.env
     echo 'UVICORN_SSL_KEYFILE = "/var/lib/marzban/certs/key.pem"' >> /opt/marzban/.env


### PR DESCRIPTION
Сертификат будет обновляться каждые 60 дней по умолчанию. После обновления сертификата **Мarzban** будет автоматически перезагружен командой `--reloadcmd "marzban restart -n"`